### PR TITLE
Update CI to use .NET 8.0.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build


### PR DESCRIPTION
Upgraded the .NET version from 6.0.x to 8.0.x in the GitHub Actions workflow. This ensures the CI environment aligns with the latest .NET version used in the example projects and tests.

Closes #25 