### PR TITLE
Update logo URL to use the correct branch reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![.Net](https://github.com/MichaelHochriegl/SignalRGen/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/MichaelHochriegl/SignalRGen/actions/workflows/ci.yml)
-# SignalRGen ![Package-Logo](https://raw.githubusercontent.com/MichaelHochriegl/SignalRGen/chore/readme/SignalRGen.Logo_32x32.png)
+# SignalRGen ![Package-Logo](https://raw.githubusercontent.com/MichaelHochriegl/SignalRGen/refs/heads/master/SignalRGen.Logo_32x32.png)
 
 > A source generator based approach to easily setup `SignalR` communication
 


### PR DESCRIPTION
Replaced the logo image URL to point to the `master` branch instead of the previous `chore/readme` branch. This ensures the logo is loaded correctly from the repository's main branch.

Closes #33 