### PR TITLE
Update logo URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![.Net](https://github.com/MichaelHochriegl/SignalRGen/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/MichaelHochriegl/SignalRGen/actions/workflows/ci.yml)
-# SignalRGen ![Package-Logo](https://raw.githubusercontent.com/MichaelHochriegl/SignalRGen/refs/heads/master/SignalRGen.Logo_32x32.png)
+# SignalRGen ![Package-Logo](https://raw.githubusercontent.com/MichaelHochriegl/SignalRGen/refs/heads/main/assets/logo_32x32.png)
 
 > A source generator based approach to easily setup `SignalR` communication
 


### PR DESCRIPTION
Corrected the logo image URL to point to the new path under the "main" branch and "assets" directory. This ensures the logo displays correctly in the README.