### PR TITLE
Set permissions for packages and contents in CI workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ env:
   # Official NuGet Feed settings
   NUGET_FEED: https://api.nuget.org/v3/index.json
   NUGET_KEY: ${{ secrets.NUGET_KEY }}
+
+permissions:
+  packages: write
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
   PROJECT_NAME: SignalRGen.Generator
   # NUGET_TEST_PROJECT: ./test/SignalRGen.Nuget.Tests.Integration
   # GitHub Packages Feed settings
-  GITHUB_FEED: https://nuget.pkg.github.com/MichaelHochriegl/index.json
+  GITHUB_FEED: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # Official NuGet Feed settings
   NUGET_FEED: https://api.nuget.org/v3/index.json


### PR DESCRIPTION
Added `packages: write` and `contents: read` permissions to the CI workflow configuration. This ensures appropriate access levels for managing packages and reading repository contents during the build process.