### PR TITLE
Add XML documentation to `SignalROptions`

### DIFF
--- a/src/SignalRGen.Generator/Sources/SignalROptionsSource.cs
+++ b/src/SignalRGen.Generator/Sources/SignalROptionsSource.cs
@@ -1,9 +1,5 @@
 using System.Text;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
-using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace SignalRGen.Generator.Sources;
 
@@ -17,9 +13,14 @@ public static class SignalROptionsSource
                                   #nullable enable
                                   namespace SignalRGen.Generator.Client.Configuration;
 
+                                  /// <summary>
+                                  /// Encapsulates the options to configure a SignalR Client.
+                                  /// </summary>
                                   public class SignalROptions
                                   {
-                                      public Uri HubBaseUri { get; set; } = default !;
+                                      /// <summary>The base <see cref="Uri"/> for the SignalR Client.</summary>
+                                      /// <remarks>This <see cref="Uri"/> will be used for every `With...` Hub defined.</remarks>
+                                      public Uri HubBaseUri { get; set; } = default!;
                                   }
                                   """;
 

--- a/tests/SignalRGen.Generator.Tests/HubClientAttributeTests.Generates_HubClientAttribute_Correctly#SignalROptions.g.verified.cs
+++ b/tests/SignalRGen.Generator.Tests/HubClientAttributeTests.Generates_HubClientAttribute_Correctly#SignalROptions.g.verified.cs
@@ -11,7 +11,12 @@
 #nullable enable
 namespace SignalRGen.Generator.Client.Configuration;
 
+/// <summary>
+/// Encapsulates the options to configure a SignalR Client.
+/// </summary>
 public class SignalROptions
 {
-    public Uri HubBaseUri { get; set; } = default !;
+    /// <summary>The base <see cref="Uri"/> for the SignalR Client.</summary>
+    /// <remarks>This <see cref="Uri"/> will be used for every `With...` Hub defined.</remarks>
+    public Uri HubBaseUri { get; set; } = default!;
 }

--- a/tests/SignalRGen.Generator.Tests/HubClientTests.Generates_HubClient_Correctly#SignalROptions.g.verified.cs
+++ b/tests/SignalRGen.Generator.Tests/HubClientTests.Generates_HubClient_Correctly#SignalROptions.g.verified.cs
@@ -11,7 +11,12 @@
 #nullable enable
 namespace SignalRGen.Generator.Client.Configuration;
 
+/// <summary>
+/// Encapsulates the options to configure a SignalR Client.
+/// </summary>
 public class SignalROptions
 {
-    public Uri HubBaseUri { get; set; } = default !;
+    /// <summary>The base <see cref="Uri"/> for the SignalR Client.</summary>
+    /// <remarks>This <see cref="Uri"/> will be used for every `With...` Hub defined.</remarks>
+    public Uri HubBaseUri { get; set; } = default!;
 }

--- a/tests/SignalRGen.Generator.Tests/HubClientTests.Generates_NamespaceNested_HubClient_Correctly#SignalROptions.g.verified.cs
+++ b/tests/SignalRGen.Generator.Tests/HubClientTests.Generates_NamespaceNested_HubClient_Correctly#SignalROptions.g.verified.cs
@@ -11,7 +11,12 @@
 #nullable enable
 namespace SignalRGen.Generator.Client.Configuration;
 
+/// <summary>
+/// Encapsulates the options to configure a SignalR Client.
+/// </summary>
 public class SignalROptions
 {
-    public Uri HubBaseUri { get; set; } = default !;
+    /// <summary>The base <see cref="Uri"/> for the SignalR Client.</summary>
+    /// <remarks>This <see cref="Uri"/> will be used for every `With...` Hub defined.</remarks>
+    public Uri HubBaseUri { get; set; } = default!;
 }


### PR DESCRIPTION
Added XML comments to the `SignalROptions` class and its `HubBaseUri` property to improve code clarity and provide context for usage. This ensures better maintainability and understanding for developers working with the SignalR client configuration.

Closes #49 