### PR TITLE
Add analyzers for validating hub and server-to-client interfaces

### DIFF
--- a/src/SignalRGen.Generator/Analyzers/HubContractAnalyzer.cs
+++ b/src/SignalRGen.Generator/Analyzers/HubContractAnalyzer.cs
@@ -1,0 +1,344 @@
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace SignalRGen.Generator.Analyzers;
+
+#region Analyzer
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class HubContractAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor MethodInHubInterfaceRule = new DiagnosticDescriptor(
+        id: "SRGN0001",
+        title: "Methods should not be declared in hub interfaces",
+        messageFormat:
+        "Method '{0}' should not be declared in interface '{1}' that inherits from a hub interface. Move methods to the appropriate client or server interface.",
+        category: "SignalRGen",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description:
+        "Hub interfaces that inherit from IBidirectionalHub, IServerToClientHub, or IClientToServerHub should not contain method declarations. Methods should be placed in the appropriate client or server interfaces.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        [MethodInHubInterfaceRule];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInterfaceDeclaration, SyntaxKind.InterfaceDeclaration);
+    }
+
+    private static void AnalyzeInterfaceDeclaration(SyntaxNodeAnalysisContext context)
+    {
+        var interfaceDeclaration = (InterfaceDeclarationSyntax)context.Node;
+        var semanticModel = context.SemanticModel;
+
+        if (ModelExtensions.GetDeclaredSymbol(semanticModel, interfaceDeclaration) is not INamedTypeSymbol
+            interfaceSymbol)
+            return;
+
+        if (!InheritsFromHubInterface(interfaceSymbol))
+            return;
+
+        var methods = interfaceDeclaration.Members.OfType<MethodDeclarationSyntax>();
+        foreach (var method in methods)
+        {
+            var diagnostic = Diagnostic.Create(
+                MethodInHubInterfaceRule,
+                method.GetLocation(),
+                method.Identifier.ValueText,
+                interfaceSymbol.Name);
+
+            context.ReportDiagnostic(diagnostic);
+        }
+    }
+
+    private static bool InheritsFromHubInterface(INamedTypeSymbol interfaceSymbol)
+    {
+        foreach (var baseInterface in interfaceSymbol.AllInterfaces)
+        {
+            var baseInterfaceName = baseInterface.Name;
+
+            if (baseInterfaceName == "IBidirectionalHub" ||
+                baseInterfaceName == "IServerToClientHub" ||
+                baseInterfaceName == "IClientToServerHub")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
+#endregion
+
+#region CodeFix
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(HubInterfaceMethodCodeFixProvider)), Shared]
+public class HubInterfaceMethodCodeFixProvider : CodeFixProvider
+{
+    public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+        [HubContractAnalyzer.MethodInHubInterfaceRule.Id];
+
+    public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null) return;
+
+        // Group diagnostics by location to avoid duplicate fixes for the same method, but even this doesn't seem to work :(
+        var diagnosticsGrouped = context.Diagnostics
+            .Where(d => FixableDiagnosticIds.Contains(d.Id))
+            .GroupBy(d => d.Location.SourceSpan)
+            .ToList();
+        
+        foreach (var diagnosticGroup in diagnosticsGrouped)
+        {
+            var diagnostic = diagnosticGroup.First();
+
+            var diagnosticSpan = diagnostic.Location.SourceSpan;
+            var methodDeclaration = root.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf()
+                .OfType<MethodDeclarationSyntax>().FirstOrDefault();
+
+            if (methodDeclaration is null) continue;
+
+            var interfaceDeclaration =
+                methodDeclaration.Ancestors().OfType<InterfaceDeclarationSyntax>().FirstOrDefault();
+            if (interfaceDeclaration is null) continue;
+
+            var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken)
+                .ConfigureAwait(false);
+            if (semanticModel is null) continue;
+
+            var interfaceSymbol = semanticModel.GetDeclaredSymbol(interfaceDeclaration);
+            if (interfaceSymbol is null) continue;
+
+            var hubInterface = FindHubInterface(interfaceSymbol);
+            if (hubInterface is null) continue;
+
+            var (serverType, clientType) = ExtractGenericTypes(hubInterface);
+            
+            var baseKey =
+                $"{interfaceSymbol.ToDisplayString()}_{methodDeclaration.Identifier.ValueText}_{methodDeclaration.Span.Start}";
+
+            if (serverType is not null)
+            {
+                var moveToServerAction = CodeAction.Create(
+                    title: $"Move to server interface ({serverType.Name})",
+                    createChangedSolution: c =>
+                        MoveMethodToInterface(context.Document, methodDeclaration, interfaceDeclaration, serverType, c),
+                    equivalenceKey: $"{baseKey}_Server_{serverType.ToDisplayString()}");
+
+                context.RegisterCodeFix(moveToServerAction, diagnostic);
+            }
+
+            if (clientType is not null)
+            {
+                var moveToClientAction = CodeAction.Create(
+                    title: $"Move to client interface ({clientType.Name})",
+                    createChangedSolution: c =>
+                        MoveMethodToInterface(context.Document, methodDeclaration, interfaceDeclaration, clientType, c),
+                    equivalenceKey: $"{baseKey}_Client_{clientType.ToDisplayString()}");
+
+                context.RegisterCodeFix(moveToClientAction, diagnostic);
+            }
+        }
+    }
+
+
+    private static INamedTypeSymbol? FindHubInterface(INamedTypeSymbol interfaceSymbol)
+    {
+        return interfaceSymbol.AllInterfaces.FirstOrDefault(i =>
+            i.Name == "IBidirectionalHub" ||
+            i.Name == "IServerToClientHub" ||
+            i.Name == "IClientToServerHub");
+    }
+
+    private static (INamedTypeSymbol? serverType, INamedTypeSymbol? clientType) ExtractGenericTypes(
+        INamedTypeSymbol hubInterface)
+    {
+        if (hubInterface is { Name: "IBidirectionalHub", TypeArguments.Length: 2 })
+        {
+            return (hubInterface.TypeArguments[0] as INamedTypeSymbol,
+                hubInterface.TypeArguments[1] as INamedTypeSymbol);
+        }
+
+        if (hubInterface is { Name: "IServerToClientHub", TypeArguments.Length: 1 })
+        {
+            return (hubInterface.TypeArguments[0] as INamedTypeSymbol, null);
+        }
+
+        if (hubInterface is { Name: "IClientToServerHub", TypeArguments.Length: 1 })
+        {
+            return (null, hubInterface.TypeArguments[0] as INamedTypeSymbol);
+        }
+
+        return (null, null);
+    }
+
+
+    private static async Task<Solution> MoveMethodToInterface(
+        Document document,
+        MethodDeclarationSyntax methodDeclaration,
+        InterfaceDeclarationSyntax sourceInterface,
+        INamedTypeSymbol targetInterface,
+        CancellationToken cancellationToken)
+    {
+        var solution = document.Project.Solution;
+
+        // Find the target interface document
+        var targetDocument = FindInterfaceDocument(solution, targetInterface);
+        if (targetDocument == null) return solution;
+
+        // Handle same document scenario
+        if (document.Id == targetDocument.Id)
+        {
+            return await MoveBothInterfacesInSameDocument(document, methodDeclaration, sourceInterface, targetInterface,
+                cancellationToken);
+        }
+
+        // Handle cross-document scenario
+        return await MoveBetweenDifferentDocuments(document, targetDocument, methodDeclaration, sourceInterface,
+            targetInterface, cancellationToken);
+    }
+
+
+    private static async Task<Solution> MoveBothInterfacesInSameDocument(
+        Document document,
+        MethodDeclarationSyntax methodDeclaration,
+        InterfaceDeclarationSyntax sourceInterface,
+        INamedTypeSymbol targetInterface,
+        CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root == null) return document.Project.Solution;
+
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (semanticModel == null) return document.Project.Solution;
+
+        // Find target interface in the same document
+        var targetInterfaceDeclaration = root.DescendantNodes()
+            .OfType<InterfaceDeclarationSyntax>()
+            .FirstOrDefault(i =>
+            {
+                var symbol = semanticModel.GetDeclaredSymbol(i);
+                return symbol?.Name == targetInterface.Name;
+            });
+
+        if (targetInterfaceDeclaration == null) return document.Project.Solution;
+
+        // Create clean method declaration
+        var cleanMethodDeclaration = methodDeclaration
+            .WithLeadingTrivia(SyntaxFactory.TriviaList(SyntaxFactory.Whitespace("    ")))
+            .WithTrailingTrivia(SyntaxFactory.TriviaList(SyntaxFactory.ElasticCarriageReturnLineFeed));
+
+        // Create updated interfaces
+        var newSourceInterface = sourceInterface.RemoveNode(methodDeclaration, SyntaxRemoveOptions.KeepNoTrivia);
+        if (newSourceInterface == null) return document.Project.Solution;
+
+        var newTargetInterface = targetInterfaceDeclaration.AddMembers(cleanMethodDeclaration);
+
+        // Use ReplaceNodes to replace both interfaces atomically
+        var nodesToReplace = new Dictionary<SyntaxNode, SyntaxNode>
+        {
+            { sourceInterface, newSourceInterface },
+            { targetInterfaceDeclaration, newTargetInterface }
+        };
+
+        var newRoot = root.ReplaceNodes(nodesToReplace.Keys, (original, _) => nodesToReplace[original]);
+
+        return document.Project.Solution.WithDocumentSyntaxRoot(document.Id, newRoot);
+    }
+
+    private static async Task<Solution> MoveBetweenDifferentDocuments(
+        Document sourceDocument,
+        Document targetDocument,
+        MethodDeclarationSyntax methodDeclaration,
+        InterfaceDeclarationSyntax sourceInterface,
+        INamedTypeSymbol targetInterface,
+        CancellationToken cancellationToken)
+    {
+        var solution = sourceDocument.Project.Solution;
+
+        // Remove method from source document
+        var sourceRoot = await sourceDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (sourceRoot == null) return solution;
+
+        var newSourceInterface = sourceInterface.RemoveNode(methodDeclaration, SyntaxRemoveOptions.KeepNoTrivia);
+        if (newSourceInterface == null) return solution;
+
+        var newSourceRoot = sourceRoot.ReplaceNode(sourceInterface, newSourceInterface);
+        solution = solution.WithDocumentSyntaxRoot(sourceDocument.Id, newSourceRoot);
+
+        // Add method to target document (using updated solution)
+        var updatedTargetDocument = solution.GetDocument(targetDocument.Id);
+        if (updatedTargetDocument == null) return solution;
+
+        var targetRoot = await updatedTargetDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (targetRoot == null) return solution;
+
+        var targetSemanticModel =
+            await updatedTargetDocument.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (targetSemanticModel == null) return solution;
+
+        var targetInterfaceDeclaration = targetRoot.DescendantNodes()
+            .OfType<InterfaceDeclarationSyntax>()
+            .FirstOrDefault(i =>
+            {
+                var symbol = targetSemanticModel.GetDeclaredSymbol(i);
+                return symbol?.Name == targetInterface.Name;
+            });
+
+        if (targetInterfaceDeclaration == null) return solution;
+
+        // Create clean method declaration
+        var cleanMethodDeclaration = methodDeclaration
+            .WithLeadingTrivia(SyntaxFactory.TriviaList(SyntaxFactory.Whitespace("    ")))
+            .WithTrailingTrivia(SyntaxFactory.TriviaList(SyntaxFactory.ElasticCarriageReturnLineFeed));
+
+        var newTargetInterface = targetInterfaceDeclaration.AddMembers(cleanMethodDeclaration);
+        var newTargetRoot = targetRoot.ReplaceNode(targetInterfaceDeclaration, newTargetInterface);
+
+        return solution.WithDocumentSyntaxRoot(updatedTargetDocument.Id, newTargetRoot);
+    }
+
+    private static Document? FindInterfaceDocument(Solution solution, INamedTypeSymbol interfaceSymbol)
+    {
+        foreach (var project in solution.Projects)
+        {
+            foreach (var document in project.Documents)
+            {
+                var semanticModel = document.GetSemanticModelAsync().Result;
+                if (semanticModel == null) continue;
+
+                var root = document.GetSyntaxRootAsync().Result;
+                if (root == null) continue;
+
+                var interfaceDeclarations = root.DescendantNodes().OfType<InterfaceDeclarationSyntax>();
+                foreach (var interfaceDecl in interfaceDeclarations)
+                {
+                    var symbol = semanticModel.GetDeclaredSymbol(interfaceDecl);
+                    if (symbol?.Name == interfaceSymbol.Name &&
+                        symbol.ContainingNamespace.ToDisplayString() ==
+                        interfaceSymbol.ContainingNamespace.ToDisplayString())
+                    {
+                        return document;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+}
+
+#endregion

--- a/src/SignalRGen.Generator/Analyzers/ServerToClientAnalyzer.cs
+++ b/src/SignalRGen.Generator/Analyzers/ServerToClientAnalyzer.cs
@@ -1,0 +1,342 @@
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace SignalRGen.Generator.Analyzers;
+
+#region Analyzer
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class ServerToClientAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor ServerToClientReturnTypeRule = new DiagnosticDescriptor(
+        id: "SRGN0002",
+        title: "Server-to-client methods must return Task, not Task<T>",
+        messageFormat:
+        "Method '{0}' in server-to-client interface '{1}' must return Task, not '{2}'. Server-to-client methods cannot have return values.",
+        category: "SignalRGen",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description:
+        "Server-to-client interfaces should only contain methods that return Task (not Task<T>) since SignalR server-to-client calls are fire-and-forget operations that don't return values to the server.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        [ServerToClientReturnTypeRule];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInterfaceDeclaration, SyntaxKind.InterfaceDeclaration);
+    }
+
+    private static void AnalyzeInterfaceDeclaration(SyntaxNodeAnalysisContext context)
+    {
+        var interfaceDeclaration = (InterfaceDeclarationSyntax)context.Node;
+        var semanticModel = context.SemanticModel;
+
+        if (ModelExtensions.GetDeclaredSymbol(semanticModel, interfaceDeclaration) is not INamedTypeSymbol
+            interfaceSymbol)
+            return;
+
+        // Check if this interface is used as a server-to-client interface
+        if (!IsServerToClientInterface(interfaceSymbol, context.Compilation))
+            return;
+
+        // Analyze all methods in this interface
+        var methods = interfaceDeclaration.Members.OfType<MethodDeclarationSyntax>();
+        foreach (var method in methods)
+        {
+            var methodSymbol = semanticModel.GetDeclaredSymbol(method);
+            if (methodSymbol == null) continue;
+
+            // Check if the return type is Task<T> instead of Task
+            if (IsGenericTask(methodSymbol.ReturnType))
+            {
+                var diagnostic = Diagnostic.Create(
+                    ServerToClientReturnTypeRule,
+                    method.ReturnType.GetLocation(),
+                    method.Identifier.ValueText,
+                    interfaceSymbol.Name,
+                    methodSymbol.ReturnType.ToDisplayString());
+
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+    }
+
+    private static bool IsServerToClientInterface(INamedTypeSymbol interfaceSymbol, Compilation compilation)
+    {
+        // Find all types that reference this interface as a server type parameter
+        var allTypes = GetAllNamedTypes(compilation);
+
+        foreach (var type in allTypes)
+        {
+            // Check if this type implements IBidirectionalHub<TServer, TClient> where TServer is our interface
+            foreach (var implementedInterface in type.AllInterfaces)
+            {
+                if (implementedInterface.Name == "IBidirectionalHub" &&
+                    implementedInterface.TypeArguments.Length == 2)
+                {
+                    var serverType = implementedInterface.TypeArguments[0];
+                    if (SymbolEqualityComparer.Default.Equals(serverType, interfaceSymbol))
+                    {
+                        return true;
+                    }
+                }
+
+                // Check if this type implements IServerToClientHub<TServer> where TServer is our interface
+                if (implementedInterface.Name == "IServerToClientHub" &&
+                    implementedInterface.TypeArguments.Length == 1)
+                {
+                    var serverType = implementedInterface.TypeArguments[0];
+                    if (SymbolEqualityComparer.Default.Equals(serverType, interfaceSymbol))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<INamedTypeSymbol> GetAllNamedTypes(Compilation compilation)
+    {
+        var allTypes = new List<INamedTypeSymbol>();
+
+        foreach (var syntaxTree in compilation.SyntaxTrees)
+        {
+            var semanticModel = compilation.GetSemanticModel(syntaxTree);
+            var root = syntaxTree.GetRoot();
+
+            var typeDeclarations = root.DescendantNodes().OfType<TypeDeclarationSyntax>();
+            foreach (var typeDecl in typeDeclarations)
+            {
+                if (semanticModel.GetDeclaredSymbol(typeDecl) is INamedTypeSymbol typeSymbol)
+                {
+                    allTypes.Add(typeSymbol);
+                }
+            }
+        }
+
+        return allTypes;
+    }
+
+    private static bool IsGenericTask(ITypeSymbol returnType)
+    {
+        // Check if it's Task<T> (generic Task with type arguments)
+        return returnType is INamedTypeSymbol namedType &&
+               namedType.Name == "Task" &&
+               namedType.ContainingNamespace.ToDisplayString() == "System.Threading.Tasks" &&
+               namedType.TypeArguments.Length > 0;
+    }
+}
+
+#endregion
+
+#region CodeFix
+
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ServerToClientReturnTypeCodeFixProvider)), Shared]
+public class ServerToClientReturnTypeCodeFixProvider : CodeFixProvider
+{
+    public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+        [ServerToClientAnalyzer.ServerToClientReturnTypeRule.Id];
+
+    public sealed override FixAllProvider GetFixAllProvider() => new ServerToClientFixAllProvider();
+
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null) return;
+
+        // Group diagnostics by location to avoid duplicate fixes for the same method, but even this doesn't seem to work :(
+        var diagnosticsGrouped = context.Diagnostics
+            .Where(d => FixableDiagnosticIds.Contains(d.Id))
+            .GroupBy(d => d.Location.SourceSpan)
+            .ToList();
+        
+        foreach (var diagnosticGroup in diagnosticsGrouped)
+        {
+            var diagnostic = diagnosticGroup.First();
+            
+            var diagnosticSpan = diagnostic.Location.SourceSpan;
+            var returnTypeNode = root.FindNode(diagnosticSpan);
+            
+            var methodDeclaration = returnTypeNode.Ancestors().OfType<MethodDeclarationSyntax>().FirstOrDefault();
+            if (methodDeclaration is null) continue;
+            
+            var interfaceDeclaration = methodDeclaration.Ancestors().OfType<InterfaceDeclarationSyntax>().FirstOrDefault();
+            if (interfaceDeclaration is null) continue;
+
+            var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+            if (semanticModel is null) continue;
+
+            var interfaceSymbol = semanticModel.GetDeclaredSymbol(interfaceDeclaration);
+            if (interfaceSymbol is null) continue;
+            
+            var baseKey = $"{interfaceSymbol.ToDisplayString()}_{methodDeclaration.Identifier.ValueText}_{methodDeclaration.Span.Start}";
+
+            var action = CodeAction.Create(
+                title: "Change return type to Task",
+                createChangedDocument: c => ConvertTaskTToTask(context.Document, methodDeclaration, c),
+                equivalenceKey: $"{baseKey}_ConvertToTask");
+
+            context.RegisterCodeFix(action, diagnostic);
+        }
+    }
+
+    private static async Task<Document> ConvertTaskTToTask(
+        Document document,
+        MethodDeclarationSyntax methodDeclaration,
+        CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null) return document;
+        
+        var newReturnType = SyntaxFactory.IdentifierName("Task")
+            .WithTriviaFrom(methodDeclaration.ReturnType);
+        
+        var newMethodDeclaration = methodDeclaration.WithReturnType(newReturnType);
+        
+        var newRoot = root.ReplaceNode(methodDeclaration, newMethodDeclaration);
+
+        return document.WithSyntaxRoot(newRoot);
+    }
+}
+
+public class ServerToClientFixAllProvider : FixAllProvider
+{
+    public override IEnumerable<FixAllScope> GetSupportedFixAllScopes()
+    {
+        return new[]
+        {
+            FixAllScope.Document,
+            FixAllScope.Project,
+            FixAllScope.Solution
+        };
+    }
+
+    public override Task<CodeAction?> GetFixAsync(FixAllContext fixAllContext)
+    {
+        return Task.FromResult<CodeAction?>(CodeAction.Create(
+            title: "Change all Task<T> to Task",
+            createChangedSolution: ct => FixAllAsync(fixAllContext, ct),
+            equivalenceKey: "FixAllServerToClientReturnTypes"));
+    }
+
+    private static async Task<Solution> FixAllAsync(FixAllContext fixAllContext, CancellationToken cancellationToken)
+    {
+        var solution = fixAllContext.Solution;
+        
+        var documentsAndDiagnostics = await GetDocumentsAndDiagnosticsAsync(fixAllContext, cancellationToken);
+        
+        var documentGroups = documentsAndDiagnostics.GroupBy(x => x.Document);
+        
+        foreach (var documentGroup in documentGroups)
+        {
+            var document = documentGroup.Key;
+            var diagnostics = documentGroup.SelectMany(x => x.Diagnostics).ToList();
+            
+            if (diagnostics.Count == 0) continue;
+            
+            var currentDocument = solution.GetDocument(document.Id);
+            if (currentDocument == null) continue;
+            
+            var updatedDocument = await FixAllInDocumentAsync(currentDocument, diagnostics, cancellationToken);
+            solution = updatedDocument.Project.Solution;
+        }
+        
+        return solution;
+    }
+
+    private static async Task<IEnumerable<(Document Document, IEnumerable<Diagnostic> Diagnostics)>> GetDocumentsAndDiagnosticsAsync(
+        FixAllContext fixAllContext, 
+        CancellationToken cancellationToken)
+    {
+        if (fixAllContext.Document is null)
+        {
+            return [];
+        }
+        var result = new List<(Document, IEnumerable<Diagnostic>)>();
+        
+        switch (fixAllContext.Scope)
+        {
+            case FixAllScope.Document:
+                var documentDiagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(fixAllContext.Document);
+                result.Add((fixAllContext.Document, documentDiagnostics));
+                break;
+                
+            case FixAllScope.Project:
+                foreach (var document in fixAllContext.Project.Documents)
+                {
+                    var projectDiagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document);
+                    if (projectDiagnostics.Any())
+                    {
+                        result.Add((document, projectDiagnostics));
+                    }
+                }
+                break;
+                
+            case FixAllScope.Solution:
+                foreach (var project in fixAllContext.Solution.Projects)
+                {
+                    foreach (var document in project.Documents)
+                    {
+                        var solutionDiagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document);
+                        if (solutionDiagnostics.Any())
+                        {
+                            result.Add((document, solutionDiagnostics));
+                        }
+                    }
+                }
+                break;
+        }
+        
+        return result;
+    }
+
+    private static async Task<Document> FixAllInDocumentAsync(
+        Document document,
+        IEnumerable<Diagnostic> diagnostics,
+        CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root == null) return document;
+        
+        var methodsToFix = new List<(MethodDeclarationSyntax Original, MethodDeclarationSyntax Fixed)>();
+
+        foreach (var diagnostic in diagnostics)
+        {
+            var diagnosticSpan = diagnostic.Location.SourceSpan;
+            var returnTypeNode = root.FindNode(diagnosticSpan);
+            
+            var methodDeclaration = returnTypeNode.Ancestors().OfType<MethodDeclarationSyntax>().FirstOrDefault();
+            if (methodDeclaration == null) continue;
+            
+            var newReturnType = SyntaxFactory.IdentifierName("Task")
+                .WithTriviaFrom(methodDeclaration.ReturnType);
+            
+            var newMethodDeclaration = methodDeclaration.WithReturnType(newReturnType);
+            
+            methodsToFix.Add((methodDeclaration, newMethodDeclaration));
+        }
+        
+        if (methodsToFix.Count > 0)
+        {
+            var nodesToReplace = methodsToFix.ToDictionary(x => (SyntaxNode)x.Original, x => (SyntaxNode)x.Fixed);
+            var newRoot = root.ReplaceNodes(nodesToReplace.Keys, (original, _) => nodesToReplace[original]);
+            return document.WithSyntaxRoot(newRoot);
+        }
+
+        return document;
+    }
+}
+
+#endregion


### PR DESCRIPTION
- Implemented `HubContractAnalyzer` for ensuring methods are not declared in hub interfaces that inherit from specific hub types.
- Created `ServerToClientAnalyzer` to enforce `Task` return type rules for server-to-client methods.
- Added corresponding code fix providers for both analyzers. These code fix providers are not working properly right now.

Closes #78 