### PR TITLE
Use `SignalRGen.Abstractions` as a runtime dependency (#89)

### DIFF
--- a/src/SignalRGen.Generator/SignalRGen.Generator.csproj
+++ b/src/SignalRGen.Generator/SignalRGen.Generator.csproj
@@ -50,7 +50,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\SignalRGen.Abstractions\SignalRGen.Abstractions.csproj" PrivateAssets="all" />
+      <ProjectReference Include="..\SignalRGen.Abstractions\SignalRGen.Abstractions.csproj" />
       <ProjectReference Include="..\SignalRGen.Analyzers\SignalRGen.Analyzers.csproj" PrivateAssets="all" />
       <ProjectReference Include="..\SignalRGen.CodeFixes\SignalRGen.CodeFixes.csproj" PrivateAssets="all" />
     </ItemGroup>


### PR DESCRIPTION
Remove `PrivateAssets="all"` from SignalRGen.Abstractions project reference to properly package it up.