### PR TITLE
Add GitHub issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,81 @@
+name: Bug report
+description: Report a reproducible problem or regression.
+title: "[Bug]: "
+labels:
+  - bug
+  - triage needed
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a question or need help? Please use [Discussions](https://github.com/MichaelHochriegl/SignalRGen/discussions) instead.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before you submit
+      description: Please confirm the following before filing.
+      options:
+        - label: I’ve searched existing issues to avoid duplicates.
+          required: true
+        - label: I’m using the latest version (or I’ve included the version info below).
+          required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+      placeholder: What happened?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide a minimal, step-by-step way to reproduce the issue.
+      placeholder: |
+        1. Go to ...
+        2. Click on ...
+        3. See error ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: What actually happened?
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version(s)
+      description: App/library version(s) affected.
+      placeholder: e.g., v1.2.3
+    validations:
+      required: false
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - Low
+        - Medium
+        - High
+        - Critical (blocks releases)
+    validations:
+      required: false
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Anything else we should know?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discussions (Q&A / ideas / help)
+    url: https://github.com/MichaelHochriegl/SignalRGen/discussions
+    about: For open-ended questions or brainstorming, use Discussions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: Feature request
+description: Suggest an idea or improvement.
+title: "[Feature]: "
+labels:
+  - enhancement
+  - triage needed
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a question or need help? Please use [Discussions](https://github.com/MichaelHochriegl/SignalRGen/discussions) instead.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before you submit
+      options:
+        - label: I’ve searched existing issues to avoid duplicates.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Related problem
+      description: Is your feature request related to a problem? Please describe.
+      placeholder: I’m frustrated when...
+    validations:
+      required: false
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to see? Be as specific as possible.
+      placeholder: Add an option to...
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      placeholder: I also considered...
+    validations:
+      required: false
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope
+      description: What does this request affect?
+      options:
+        - label: Library
+        - label: Docs / Examples
+        - label: Repo
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Links, screenshots, or prototypes
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+## Summary
+<!-- What does this PR change and why? Keep it concise. -->
+
+## Related issues
+<!-- Link issues with "Closes #123" or "Relates to #123". -->
+Closes #


### PR DESCRIPTION
## Summary
Adds templates for easier issue and pull request creation.

## Related issues
Closes #82 