### PR TITLE
Add recursive interface methods extension and integrate into analyzers

### DIFF
--- a/src/SignalRGen.Analyzers/ClientToServerAnalyzer.cs
+++ b/src/SignalRGen.Analyzers/ClientToServerAnalyzer.cs
@@ -38,7 +38,7 @@ public class ClientToServerAnalyzer : DiagnosticAnalyzer
 
         if (!IsClientToServerInterface(interfaceSymbol, context.Compilation, context.CancellationToken)) return;
         
-        var methods = interfaceSymbol.GetMembers();
+        var methods = interfaceSymbol.GetInterfaceMethodsRecursively();
         foreach (var method in methods)
         {
             if (method is not IMethodSymbol methodSymbol) continue;

--- a/src/SignalRGen.Analyzers/Extensions/SymbolExtensions.cs
+++ b/src/SignalRGen.Analyzers/Extensions/SymbolExtensions.cs
@@ -1,0 +1,45 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+
+namespace SignalRGen.Analyzers.Extensions;
+
+internal static class SymbolExtensions
+{
+    /// <summary>
+    /// Retrieves all methods declared within the provided interface as well as all methods from its inherited interfaces, recursively.
+    /// </summary>
+    /// <param name="interfaceSymbol">The interface symbol representing the interface to retrieve methods from.</param>
+    /// <returns>An immutable array of method symbols, containing all methods from the interface and its base interfaces.</returns>
+    public static ImmutableArray<IMethodSymbol> GetInterfaceMethodsRecursively(this INamedTypeSymbol interfaceSymbol)
+    {
+        var methods = new List<IMethodSymbol>();
+        var visited = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+
+        CollectMethodsRecursively(interfaceSymbol, methods, visited);
+
+        return [..methods];
+    }
+
+    private static void CollectMethodsRecursively(INamedTypeSymbol interfaceSymbol, List<IMethodSymbol> methods,
+        HashSet<INamedTypeSymbol> visited)
+    {
+        if (!visited.Add(interfaceSymbol)) return;
+        
+        foreach (var member in interfaceSymbol.GetMembers())
+        {
+            if (member is IMethodSymbol methodSymbol)
+            {
+                methods.Add(methodSymbol);
+            }
+            else if (member is INamedTypeSymbol namedTypeSymbol)
+            {
+                CollectMethodsRecursively(namedTypeSymbol, methods, visited);
+            }
+        }
+
+        foreach (var baseInterface in interfaceSymbol.AllInterfaces)
+        {
+            CollectMethodsRecursively(baseInterface, methods, visited);
+        }
+    }
+}

--- a/src/SignalRGen.Analyzers/ServerToClientAnalyzer.cs
+++ b/src/SignalRGen.Analyzers/ServerToClientAnalyzer.cs
@@ -41,7 +41,7 @@ public class ServerToClientAnalyzer : DiagnosticAnalyzer
         if (!IsServerToClientInterface(interfaceSymbol, context.Compilation, context.CancellationToken))
             return;
         
-        var methods = interfaceSymbol.GetMembers();
+        var methods = interfaceSymbol.GetInterfaceMethodsRecursively();
         foreach (var method in methods)
         {
             if (method is not IMethodSymbol methodSymbol) continue;


### PR DESCRIPTION
## Summary
Recursively checks the interface methods for violations regarding SignalRGen rules for SignalR method definitions.

## Related issues
Closes #95 