### PR TITLE
Refactor HubClient delegate models for improved parameter handling

### DIFF
--- a/src/SignalRGen.Generator/Sources/HubClient.sbntxt
+++ b/src/SignalRGen.Generator/Sources/HubClient.sbntxt
@@ -29,11 +29,9 @@ public class {{ hub_name }} : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method {{ method.identifier }} of the <see cref = "{{ full_interface_name }}"/> gets invoked.
     /// </summary>
-    {{~ if method.has_parameters ~}}
-    public global::System.Func<{{ method.parameter_types }}, global::System.Threading.Tasks.Task>? On{{ method.identifier }} = default;
-    {{~ else ~}}
-    public global::System.Func<global::System.Threading.Tasks.Task>? On{{ method.identifier }} = default;
-    {{~ end ~}}
+    public delegate global::System.Threading.Tasks.Task {{ method.identifier }}Delegate({{ method.parameter_list }});
+    public {{ method.identifier }}Delegate? On{{ method.identifier }} = default;
+    
     private global::System.Threading.Tasks.Task {{ method.identifier }}Handler({{ method.parameter_list }})
     {
         return On{{ method.identifier }}?.Invoke({{ method.parameter_names }}) ?? global::System.Threading.Tasks.Task.CompletedTask;

--- a/tests/SignalRGen.Generator.Tests/Snapshots/HubClientInheritanceTests/HubClientInheritanceTests.Generates_HubClient_WithGenericParameters_Correctly#ExampleHubClient.g.verified.cs
+++ b/tests/SignalRGen.Generator.Tests/Snapshots/HubClientInheritanceTests/HubClientInheritanceTests.Generates_HubClient_WithGenericParameters_Correctly#ExampleHubClient.g.verified.cs
@@ -29,7 +29,9 @@ public class ExampleHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveExampleCountUpdate of the <see cref = "global::SignalRGen.Example.Contracts.IExampleHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<int, global::System.Threading.Tasks.Task>? OnReceiveExampleCountUpdate = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveExampleCountUpdateDelegate(int count);
+    public ReceiveExampleCountUpdateDelegate? OnReceiveExampleCountUpdate = default;
+    
     private global::System.Threading.Tasks.Task ReceiveExampleCountUpdateHandler(int count)
     {
         return OnReceiveExampleCountUpdate?.Invoke(count) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -37,7 +39,9 @@ public class ExampleHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveCollection of the <see cref = "global::SignalRGen.Example.Contracts.IExampleHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<global::System.Collections.Generic.IEnumerable<T>, global::System.Threading.Tasks.Task>? OnReceiveCollection = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveCollectionDelegate(global::System.Collections.Generic.IEnumerable<T> items);
+    public ReceiveCollectionDelegate? OnReceiveCollection = default;
+    
     private global::System.Threading.Tasks.Task ReceiveCollectionHandler(global::System.Collections.Generic.IEnumerable<T> items)
     {
         return OnReceiveCollection?.Invoke(items) ?? global::System.Threading.Tasks.Task.CompletedTask;

--- a/tests/SignalRGen.Generator.Tests/Snapshots/HubClientInheritanceTests/HubClientInheritanceTests.Generates_HubClient_WithMixedInterfaceMethods_Correctly#ExampleHubClient.g.verified.cs
+++ b/tests/SignalRGen.Generator.Tests/Snapshots/HubClientInheritanceTests/HubClientInheritanceTests.Generates_HubClient_WithMixedInterfaceMethods_Correctly#ExampleHubClient.g.verified.cs
@@ -29,7 +29,9 @@ public class ExampleHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveExampleCountUpdate of the <see cref = "global::SignalRGen.Example.Contracts.IExampleHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<int, global::System.Threading.Tasks.Task>? OnReceiveExampleCountUpdate = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveExampleCountUpdateDelegate(int count);
+    public ReceiveExampleCountUpdateDelegate? OnReceiveExampleCountUpdate = default;
+    
     private global::System.Threading.Tasks.Task ReceiveExampleCountUpdateHandler(int count)
     {
         return OnReceiveExampleCountUpdate?.Invoke(count) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -37,7 +39,9 @@ public class ExampleHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveBaseMessage of the <see cref = "global::SignalRGen.Example.Contracts.IExampleHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<string, global::System.Threading.Tasks.Task>? OnReceiveBaseMessage = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveBaseMessageDelegate(string message);
+    public ReceiveBaseMessageDelegate? OnReceiveBaseMessage = default;
+    
     private global::System.Threading.Tasks.Task ReceiveBaseMessageHandler(string message)
     {
         return OnReceiveBaseMessage?.Invoke(message) ?? global::System.Threading.Tasks.Task.CompletedTask;

--- a/tests/SignalRGen.Generator.Tests/Snapshots/HubClientInheritanceTests/HubClientInheritanceTests.Generates_HubClient_WithMultiLevelInheritance_Correctly#ExampleHubClient.g.verified.cs
+++ b/tests/SignalRGen.Generator.Tests/Snapshots/HubClientInheritanceTests/HubClientInheritanceTests.Generates_HubClient_WithMultiLevelInheritance_Correctly#ExampleHubClient.g.verified.cs
@@ -29,7 +29,9 @@ public class ExampleHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveExampleCountUpdate of the <see cref = "global::SignalRGen.Example.Contracts.IExampleHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<int, global::System.Threading.Tasks.Task>? OnReceiveExampleCountUpdate = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveExampleCountUpdateDelegate(int count);
+    public ReceiveExampleCountUpdateDelegate? OnReceiveExampleCountUpdate = default;
+    
     private global::System.Threading.Tasks.Task ReceiveExampleCountUpdateHandler(int count)
     {
         return OnReceiveExampleCountUpdate?.Invoke(count) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -37,7 +39,9 @@ public class ExampleHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveBaseMessage of the <see cref = "global::SignalRGen.Example.Contracts.IExampleHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<string, global::System.Threading.Tasks.Task>? OnReceiveBaseMessage = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveBaseMessageDelegate(string message);
+    public ReceiveBaseMessageDelegate? OnReceiveBaseMessage = default;
+    
     private global::System.Threading.Tasks.Task ReceiveBaseMessageHandler(string message)
     {
         return OnReceiveBaseMessage?.Invoke(message) ?? global::System.Threading.Tasks.Task.CompletedTask;

--- a/tests/SignalRGen.Generator.Tests/Snapshots/HubClientInheritanceTests/HubClientInheritanceTests.Generates_HubClient_WithMultipleBaseInterfaces_Correctly#ExampleHubClient.g.verified.cs
+++ b/tests/SignalRGen.Generator.Tests/Snapshots/HubClientInheritanceTests/HubClientInheritanceTests.Generates_HubClient_WithMultipleBaseInterfaces_Correctly#ExampleHubClient.g.verified.cs
@@ -29,7 +29,9 @@ public class ExampleHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveExampleCountUpdate of the <see cref = "global::SignalRGen.Example.Contracts.IExampleHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<int, global::System.Threading.Tasks.Task>? OnReceiveExampleCountUpdate = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveExampleCountUpdateDelegate(int count);
+    public ReceiveExampleCountUpdateDelegate? OnReceiveExampleCountUpdate = default;
+    
     private global::System.Threading.Tasks.Task ReceiveExampleCountUpdateHandler(int count)
     {
         return OnReceiveExampleCountUpdate?.Invoke(count) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -37,7 +39,9 @@ public class ExampleHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveBase1Message of the <see cref = "global::SignalRGen.Example.Contracts.IExampleHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<string, global::System.Threading.Tasks.Task>? OnReceiveBase1Message = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveBase1MessageDelegate(string message);
+    public ReceiveBase1MessageDelegate? OnReceiveBase1Message = default;
+    
     private global::System.Threading.Tasks.Task ReceiveBase1MessageHandler(string message)
     {
         return OnReceiveBase1Message?.Invoke(message) ?? global::System.Threading.Tasks.Task.CompletedTask;

--- a/tests/SignalRGen.Generator.Tests/Snapshots/HubClientInheritanceTests/HubClientInheritanceTests.Generates_HubClient_WithOnlyBaseInterfaceMethods_Correctly#ExampleHubClient.g.verified.cs
+++ b/tests/SignalRGen.Generator.Tests/Snapshots/HubClientInheritanceTests/HubClientInheritanceTests.Generates_HubClient_WithOnlyBaseInterfaceMethods_Correctly#ExampleHubClient.g.verified.cs
@@ -29,7 +29,9 @@ public class ExampleHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveBaseMessage of the <see cref = "global::SignalRGen.Example.Contracts.IExampleHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<string, global::System.Threading.Tasks.Task>? OnReceiveBaseMessage = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveBaseMessageDelegate(string message);
+    public ReceiveBaseMessageDelegate? OnReceiveBaseMessage = default;
+    
     private global::System.Threading.Tasks.Task ReceiveBaseMessageHandler(string message)
     {
         return OnReceiveBaseMessage?.Invoke(message) ?? global::System.Threading.Tasks.Task.CompletedTask;

--- a/tests/SignalRGen.Generator.Tests/Snapshots/HubClientServerToClientTests/HubClientServerToClientTests.Generates_HubClient_WithServerToClientHub_Correctly#NotificationHubClient.g.verified.cs
+++ b/tests/SignalRGen.Generator.Tests/Snapshots/HubClientServerToClientTests/HubClientServerToClientTests.Generates_HubClient_WithServerToClientHub_Correctly#NotificationHubClient.g.verified.cs
@@ -29,7 +29,9 @@ public class NotificationHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveNotification of the <see cref = "global::SignalRGen.Clients.INotificationHubClient"/> gets invoked.
     /// </summary>
-    public global::System.Func<string, string, global::System.Threading.Tasks.Task>? OnReceiveNotification = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveNotificationDelegate(string message, string type);
+    public ReceiveNotificationDelegate? OnReceiveNotification = default;
+    
     private global::System.Threading.Tasks.Task ReceiveNotificationHandler(string message, string type)
     {
         return OnReceiveNotification?.Invoke(message, type) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -37,7 +39,9 @@ public class NotificationHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveAlert of the <see cref = "global::SignalRGen.Clients.INotificationHubClient"/> gets invoked.
     /// </summary>
-    public global::System.Func<string, int, global::System.Threading.Tasks.Task>? OnReceiveAlert = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveAlertDelegate(string alertMessage, int severity);
+    public ReceiveAlertDelegate? OnReceiveAlert = default;
+    
     private global::System.Threading.Tasks.Task ReceiveAlertHandler(string alertMessage, int severity)
     {
         return OnReceiveAlert?.Invoke(alertMessage, severity) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -45,7 +49,9 @@ public class NotificationHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveCustomTypeUpdate of the <see cref = "global::SignalRGen.Clients.INotificationHubClient"/> gets invoked.
     /// </summary>
-    public global::System.Func<global::SignalRGen.Generator.Tests.TestData.CustomTypeDto, global::System.Threading.Tasks.Task>? OnReceiveCustomTypeUpdate = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveCustomTypeUpdateDelegate(global::SignalRGen.Generator.Tests.TestData.CustomTypeDto dto);
+    public ReceiveCustomTypeUpdateDelegate? OnReceiveCustomTypeUpdate = default;
+    
     private global::System.Threading.Tasks.Task ReceiveCustomTypeUpdateHandler(global::SignalRGen.Generator.Tests.TestData.CustomTypeDto dto)
     {
         return OnReceiveCustomTypeUpdate?.Invoke(dto) ?? global::System.Threading.Tasks.Task.CompletedTask;

--- a/tests/SignalRGen.Generator.Tests/Snapshots/HubClientServerToClientTests/HubClientServerToClientTests.Generates_HubClient_WithServerToClientHub_WithComplexTypes_Correctly#ComplexNotificationHubClient.g.verified.cs
+++ b/tests/SignalRGen.Generator.Tests/Snapshots/HubClientServerToClientTests/HubClientServerToClientTests.Generates_HubClient_WithServerToClientHub_WithComplexTypes_Correctly#ComplexNotificationHubClient.g.verified.cs
@@ -29,7 +29,9 @@ public class ComplexNotificationHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveUserList of the <see cref = "global::SignalRGen.Clients.IComplexNotificationHubClient"/> gets invoked.
     /// </summary>
-    public global::System.Func<List<global::SignalRGen.Generator.Tests.TestData.CustomTypeDto>, global::System.Threading.Tasks.Task>? OnReceiveUserList = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveUserListDelegate(List<global::SignalRGen.Generator.Tests.TestData.CustomTypeDto> users);
+    public ReceiveUserListDelegate? OnReceiveUserList = default;
+    
     private global::System.Threading.Tasks.Task ReceiveUserListHandler(List<global::SignalRGen.Generator.Tests.TestData.CustomTypeDto> users)
     {
         return OnReceiveUserList?.Invoke(users) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -37,7 +39,9 @@ public class ComplexNotificationHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveDataUpdate of the <see cref = "global::SignalRGen.Clients.IComplexNotificationHubClient"/> gets invoked.
     /// </summary>
-    public global::System.Func<Dictionary<string, int>, global::System.Threading.Tasks.Task>? OnReceiveDataUpdate = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveDataUpdateDelegate(Dictionary<string, int> metrics);
+    public ReceiveDataUpdateDelegate? OnReceiveDataUpdate = default;
+    
     private global::System.Threading.Tasks.Task ReceiveDataUpdateHandler(Dictionary<string, int> metrics)
     {
         return OnReceiveDataUpdate?.Invoke(metrics) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -45,7 +49,9 @@ public class ComplexNotificationHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveNullableData of the <see cref = "global::SignalRGen.Clients.IComplexNotificationHubClient"/> gets invoked.
     /// </summary>
-    public global::System.Func<string, int?, global::System.Threading.Tasks.Task>? OnReceiveNullableData = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveNullableDataDelegate(string nullableMessage, int? nullableCount);
+    public ReceiveNullableDataDelegate? OnReceiveNullableData = default;
+    
     private global::System.Threading.Tasks.Task ReceiveNullableDataHandler(string nullableMessage, int? nullableCount)
     {
         return OnReceiveNullableData?.Invoke(nullableMessage, nullableCount) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -53,7 +59,9 @@ public class ComplexNotificationHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveArrayData of the <see cref = "global::SignalRGen.Clients.IComplexNotificationHubClient"/> gets invoked.
     /// </summary>
-    public global::System.Func<string[], global::SignalRGen.Generator.Tests.TestData.CustomTypeDto[], global::System.Threading.Tasks.Task>? OnReceiveArrayData = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveArrayDataDelegate(string[] messages, global::SignalRGen.Generator.Tests.TestData.CustomTypeDto[] dtos);
+    public ReceiveArrayDataDelegate? OnReceiveArrayData = default;
+    
     private global::System.Threading.Tasks.Task ReceiveArrayDataHandler(string[] messages, global::SignalRGen.Generator.Tests.TestData.CustomTypeDto[] dtos)
     {
         return OnReceiveArrayData?.Invoke(messages, dtos) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -61,7 +69,9 @@ public class ComplexNotificationHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveTupleData of the <see cref = "global::SignalRGen.Clients.IComplexNotificationHubClient"/> gets invoked.
     /// </summary>
-    public global::System.Func<(string name, int value), global::System.Threading.Tasks.Task>? OnReceiveTupleData = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveTupleDataDelegate((string name, int value) tupleData);
+    public ReceiveTupleDataDelegate? OnReceiveTupleData = default;
+    
     private global::System.Threading.Tasks.Task ReceiveTupleDataHandler((string name, int value) tupleData)
     {
         return OnReceiveTupleData?.Invoke(tupleData) ?? global::System.Threading.Tasks.Task.CompletedTask;

--- a/tests/SignalRGen.Generator.Tests/Snapshots/HubClientServerToClientTests/HubClientServerToClientTests.Generates_HubClient_WithServerToClientHub_WithInheritance_Correctly#ExtendedNotificationHubClient.g.verified.cs
+++ b/tests/SignalRGen.Generator.Tests/Snapshots/HubClientServerToClientTests/HubClientServerToClientTests.Generates_HubClient_WithServerToClientHub_WithInheritance_Correctly#ExtendedNotificationHubClient.g.verified.cs
@@ -29,7 +29,9 @@ public class ExtendedNotificationHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveExtendedNotification of the <see cref = "global::SignalRGen.Clients.IExtendedNotificationHubClient"/> gets invoked.
     /// </summary>
-    public global::System.Func<string, int, global::System.Threading.Tasks.Task>? OnReceiveExtendedNotification = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveExtendedNotificationDelegate(string message, int priority);
+    public ReceiveExtendedNotificationDelegate? OnReceiveExtendedNotification = default;
+    
     private global::System.Threading.Tasks.Task ReceiveExtendedNotificationHandler(string message, int priority)
     {
         return OnReceiveExtendedNotification?.Invoke(message, priority) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -37,7 +39,9 @@ public class ExtendedNotificationHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveCustomTypeNotification of the <see cref = "global::SignalRGen.Clients.IExtendedNotificationHubClient"/> gets invoked.
     /// </summary>
-    public global::System.Func<global::SignalRGen.Generator.Tests.TestData.CustomTypeDto, global::System.Threading.Tasks.Task>? OnReceiveCustomTypeNotification = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveCustomTypeNotificationDelegate(global::SignalRGen.Generator.Tests.TestData.CustomTypeDto dto);
+    public ReceiveCustomTypeNotificationDelegate? OnReceiveCustomTypeNotification = default;
+    
     private global::System.Threading.Tasks.Task ReceiveCustomTypeNotificationHandler(global::SignalRGen.Generator.Tests.TestData.CustomTypeDto dto)
     {
         return OnReceiveCustomTypeNotification?.Invoke(dto) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -45,7 +49,9 @@ public class ExtendedNotificationHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveBaseNotification of the <see cref = "global::SignalRGen.Clients.IExtendedNotificationHubClient"/> gets invoked.
     /// </summary>
-    public global::System.Func<string, global::System.Threading.Tasks.Task>? OnReceiveBaseNotification = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveBaseNotificationDelegate(string message);
+    public ReceiveBaseNotificationDelegate? OnReceiveBaseNotification = default;
+    
     private global::System.Threading.Tasks.Task ReceiveBaseNotificationHandler(string message)
     {
         return OnReceiveBaseNotification?.Invoke(message) ?? global::System.Threading.Tasks.Task.CompletedTask;

--- a/tests/SignalRGen.Generator.Tests/Snapshots/HubClientServerToClientTests/HubClientServerToClientTests.Generates_HubClient_WithServerToClientHub_WithMultiLevelInheritance_Correctly#MultiLevelNotificationHubClient.g.verified.cs
+++ b/tests/SignalRGen.Generator.Tests/Snapshots/HubClientServerToClientTests/HubClientServerToClientTests.Generates_HubClient_WithServerToClientHub_WithMultiLevelInheritance_Correctly#MultiLevelNotificationHubClient.g.verified.cs
@@ -29,7 +29,9 @@ public class MultiLevelNotificationHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveTopNotification of the <see cref = "global::SignalRGen.Clients.IMultiLevelNotificationHubClient"/> gets invoked.
     /// </summary>
-    public global::System.Func<global::SignalRGen.Generator.Tests.TestData.CustomTypeDto, global::System.Threading.Tasks.Task>? OnReceiveTopNotification = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveTopNotificationDelegate(global::SignalRGen.Generator.Tests.TestData.CustomTypeDto dto);
+    public ReceiveTopNotificationDelegate? OnReceiveTopNotification = default;
+    
     private global::System.Threading.Tasks.Task ReceiveTopNotificationHandler(global::SignalRGen.Generator.Tests.TestData.CustomTypeDto dto)
     {
         return OnReceiveTopNotification?.Invoke(dto) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -37,7 +39,9 @@ public class MultiLevelNotificationHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveMidNotification of the <see cref = "global::SignalRGen.Clients.IMultiLevelNotificationHubClient"/> gets invoked.
     /// </summary>
-    public global::System.Func<int, global::System.Threading.Tasks.Task>? OnReceiveMidNotification = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveMidNotificationDelegate(int value);
+    public ReceiveMidNotificationDelegate? OnReceiveMidNotification = default;
+    
     private global::System.Threading.Tasks.Task ReceiveMidNotificationHandler(int value)
     {
         return OnReceiveMidNotification?.Invoke(value) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -45,7 +49,9 @@ public class MultiLevelNotificationHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveBaseNotification of the <see cref = "global::SignalRGen.Clients.IMultiLevelNotificationHubClient"/> gets invoked.
     /// </summary>
-    public global::System.Func<string, global::System.Threading.Tasks.Task>? OnReceiveBaseNotification = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveBaseNotificationDelegate(string message);
+    public ReceiveBaseNotificationDelegate? OnReceiveBaseNotification = default;
+    
     private global::System.Threading.Tasks.Task ReceiveBaseNotificationHandler(string message)
     {
         return OnReceiveBaseNotification?.Invoke(message) ?? global::System.Threading.Tasks.Task.CompletedTask;

--- a/tests/SignalRGen.Generator.Tests/Snapshots/HubClientServerToClientTests/HubClientServerToClientTests.Generates_HubClient_WithServerToClientHub_WithNestedNamespace_Correctly#NestedNotificationHubClient.g.verified.cs
+++ b/tests/SignalRGen.Generator.Tests/Snapshots/HubClientServerToClientTests/HubClientServerToClientTests.Generates_HubClient_WithServerToClientHub_WithNestedNamespace_Correctly#NestedNotificationHubClient.g.verified.cs
@@ -29,7 +29,9 @@ public class NestedNotificationHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveNestedNotification of the <see cref = "global::SignalRGen.Clients.Nested.INestedNotificationHubClient"/> gets invoked.
     /// </summary>
-    public global::System.Func<string, global::System.Threading.Tasks.Task>? OnReceiveNestedNotification = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveNestedNotificationDelegate(string message);
+    public ReceiveNestedNotificationDelegate? OnReceiveNestedNotification = default;
+    
     private global::System.Threading.Tasks.Task ReceiveNestedNotificationHandler(string message)
     {
         return OnReceiveNestedNotification?.Invoke(message) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -37,7 +39,9 @@ public class NestedNotificationHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveNestedData of the <see cref = "global::SignalRGen.Clients.Nested.INestedNotificationHubClient"/> gets invoked.
     /// </summary>
-    public global::System.Func<global::SignalRGen.Generator.Tests.TestData.CustomTypeDto, global::System.Threading.Tasks.Task>? OnReceiveNestedData = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveNestedDataDelegate(global::SignalRGen.Generator.Tests.TestData.CustomTypeDto dto);
+    public ReceiveNestedDataDelegate? OnReceiveNestedData = default;
+    
     private global::System.Threading.Tasks.Task ReceiveNestedDataHandler(global::SignalRGen.Generator.Tests.TestData.CustomTypeDto dto)
     {
         return OnReceiveNestedData?.Invoke(dto) ?? global::System.Threading.Tasks.Task.CompletedTask;

--- a/tests/SignalRGen.Generator.Tests/Snapshots/HubClientServerToClientTests/HubClientServerToClientTests.Generates_HubClient_WithServerToClientHub_WithNoParameters_Correctly#ParameterlessNotificationHubClient.g.verified.cs
+++ b/tests/SignalRGen.Generator.Tests/Snapshots/HubClientServerToClientTests/HubClientServerToClientTests.Generates_HubClient_WithServerToClientHub_WithNoParameters_Correctly#ParameterlessNotificationHubClient.g.verified.cs
@@ -29,7 +29,9 @@ public class ParameterlessNotificationHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveHeartbeat of the <see cref = "global::SignalRGen.Clients.IParameterlessNotificationHubClient"/> gets invoked.
     /// </summary>
-    public global::System.Func<global::System.Threading.Tasks.Task>? OnReceiveHeartbeat = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveHeartbeatDelegate();
+    public ReceiveHeartbeatDelegate? OnReceiveHeartbeat = default;
+    
     private global::System.Threading.Tasks.Task ReceiveHeartbeatHandler()
     {
         return OnReceiveHeartbeat?.Invoke() ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -37,7 +39,9 @@ public class ParameterlessNotificationHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveRefreshSignal of the <see cref = "global::SignalRGen.Clients.IParameterlessNotificationHubClient"/> gets invoked.
     /// </summary>
-    public global::System.Func<global::System.Threading.Tasks.Task>? OnReceiveRefreshSignal = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveRefreshSignalDelegate();
+    public ReceiveRefreshSignalDelegate? OnReceiveRefreshSignal = default;
+    
     private global::System.Threading.Tasks.Task ReceiveRefreshSignalHandler()
     {
         return OnReceiveRefreshSignal?.Invoke() ?? global::System.Threading.Tasks.Task.CompletedTask;

--- a/tests/SignalRGen.Generator.Tests/Snapshots/HubClientTests/HubClientTests.Generates_HubClient_Correctly#TestHubClient.g.verified.cs
+++ b/tests/SignalRGen.Generator.Tests/Snapshots/HubClientTests/HubClientTests.Generates_HubClient_Correctly#TestHubClient.g.verified.cs
@@ -29,7 +29,9 @@ public class TestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveCustomTypeUpdate of the <see cref = "global::SignalRGen.Clients.ITestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<IEnumerable<global::SignalRGen.Generator.Tests.TestData.CustomTypeDto>, global::System.Threading.Tasks.Task>? OnReceiveCustomTypeUpdate = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveCustomTypeUpdateDelegate(IEnumerable<global::SignalRGen.Generator.Tests.TestData.CustomTypeDto> customTypes);
+    public ReceiveCustomTypeUpdateDelegate? OnReceiveCustomTypeUpdate = default;
+    
     private global::System.Threading.Tasks.Task ReceiveCustomTypeUpdateHandler(IEnumerable<global::SignalRGen.Generator.Tests.TestData.CustomTypeDto> customTypes)
     {
         return OnReceiveCustomTypeUpdate?.Invoke(customTypes) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -37,7 +39,9 @@ public class TestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveFooUpdate of the <see cref = "global::SignalRGen.Clients.ITestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<string, int, global::System.Threading.Tasks.Task>? OnReceiveFooUpdate = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveFooUpdateDelegate(string bar, int bass);
+    public ReceiveFooUpdateDelegate? OnReceiveFooUpdate = default;
+    
     private global::System.Threading.Tasks.Task ReceiveFooUpdateHandler(string bar, int bass)
     {
         return OnReceiveFooUpdate?.Invoke(bar, bass) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -45,7 +49,9 @@ public class TestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveNormalTypeWithSpecificAttributeApplied of the <see cref = "global::SignalRGen.Clients.ITestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<string, int, global::System.Threading.Tasks.Task>? OnReceiveNormalTypeWithSpecificAttributeApplied = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveNormalTypeWithSpecificAttributeAppliedDelegate(string bazz, int buzz);
+    public ReceiveNormalTypeWithSpecificAttributeAppliedDelegate? OnReceiveNormalTypeWithSpecificAttributeApplied = default;
+    
     private global::System.Threading.Tasks.Task ReceiveNormalTypeWithSpecificAttributeAppliedHandler(string bazz, int buzz)
     {
         return OnReceiveNormalTypeWithSpecificAttributeApplied?.Invoke(bazz, buzz) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -53,7 +59,9 @@ public class TestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveWithArbitraryAttribute of the <see cref = "global::SignalRGen.Clients.ITestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<int, global::System.Threading.Tasks.Task>? OnReceiveWithArbitraryAttribute = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveWithArbitraryAttributeDelegate(int blub);
+    public ReceiveWithArbitraryAttributeDelegate? OnReceiveWithArbitraryAttribute = default;
+    
     private global::System.Threading.Tasks.Task ReceiveWithArbitraryAttributeHandler(int blub)
     {
         return OnReceiveWithArbitraryAttribute?.Invoke(blub) ?? global::System.Threading.Tasks.Task.CompletedTask;

--- a/tests/SignalRGen.Generator.Tests/Snapshots/HubClientTests/HubClientTests.Generates_HubClient_WithArrayTypes_Correctly#ArrayTestHubClient.g.verified.cs
+++ b/tests/SignalRGen.Generator.Tests/Snapshots/HubClientTests/HubClientTests.Generates_HubClient_WithArrayTypes_Correctly#ArrayTestHubClient.g.verified.cs
@@ -29,7 +29,9 @@ public class ArrayTestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveStringArray of the <see cref = "global::SignalRGen.Clients.IArrayTestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<string[], global::System.Threading.Tasks.Task>? OnReceiveStringArray = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveStringArrayDelegate(string[] messages);
+    public ReceiveStringArrayDelegate? OnReceiveStringArray = default;
+    
     private global::System.Threading.Tasks.Task ReceiveStringArrayHandler(string[] messages)
     {
         return OnReceiveStringArray?.Invoke(messages) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -37,7 +39,9 @@ public class ArrayTestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveIntArray of the <see cref = "global::SignalRGen.Clients.IArrayTestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<int[], global::System.Threading.Tasks.Task>? OnReceiveIntArray = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveIntArrayDelegate(int[] numbers);
+    public ReceiveIntArrayDelegate? OnReceiveIntArray = default;
+    
     private global::System.Threading.Tasks.Task ReceiveIntArrayHandler(int[] numbers)
     {
         return OnReceiveIntArray?.Invoke(numbers) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -45,7 +49,9 @@ public class ArrayTestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveCustomTypeArray of the <see cref = "global::SignalRGen.Clients.IArrayTestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<global::SignalRGen.Generator.Tests.TestData.CustomTypeDto[], global::System.Threading.Tasks.Task>? OnReceiveCustomTypeArray = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveCustomTypeArrayDelegate(global::SignalRGen.Generator.Tests.TestData.CustomTypeDto[] dtos);
+    public ReceiveCustomTypeArrayDelegate? OnReceiveCustomTypeArray = default;
+    
     private global::System.Threading.Tasks.Task ReceiveCustomTypeArrayHandler(global::SignalRGen.Generator.Tests.TestData.CustomTypeDto[] dtos)
     {
         return OnReceiveCustomTypeArray?.Invoke(dtos) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -53,7 +59,9 @@ public class ArrayTestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveMultidimensionalArray of the <see cref = "global::SignalRGen.Clients.IArrayTestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<int[,], global::System.Threading.Tasks.Task>? OnReceiveMultidimensionalArray = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveMultidimensionalArrayDelegate(int[,] matrix);
+    public ReceiveMultidimensionalArrayDelegate? OnReceiveMultidimensionalArray = default;
+    
     private global::System.Threading.Tasks.Task ReceiveMultidimensionalArrayHandler(int[,] matrix)
     {
         return OnReceiveMultidimensionalArray?.Invoke(matrix) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -61,7 +69,9 @@ public class ArrayTestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveJaggedArray of the <see cref = "global::SignalRGen.Clients.IArrayTestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<string[][], global::System.Threading.Tasks.Task>? OnReceiveJaggedArray = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveJaggedArrayDelegate(string[][] jaggedArray);
+    public ReceiveJaggedArrayDelegate? OnReceiveJaggedArray = default;
+    
     private global::System.Threading.Tasks.Task ReceiveJaggedArrayHandler(string[][] jaggedArray)
     {
         return OnReceiveJaggedArray?.Invoke(jaggedArray) ?? global::System.Threading.Tasks.Task.CompletedTask;

--- a/tests/SignalRGen.Generator.Tests/Snapshots/HubClientTests/HubClientTests.Generates_HubClient_WithComplexGenericTypes_Correctly#GenericTestHubClient.g.verified.cs
+++ b/tests/SignalRGen.Generator.Tests/Snapshots/HubClientTests/HubClientTests.Generates_HubClient_WithComplexGenericTypes_Correctly#GenericTestHubClient.g.verified.cs
@@ -29,7 +29,9 @@ public class GenericTestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveGenericList of the <see cref = "global::SignalRGen.Clients.IGenericTestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<List<global::SignalRGen.Generator.Tests.TestData.CustomTypeDto>, global::System.Threading.Tasks.Task>? OnReceiveGenericList = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveGenericListDelegate(List<global::SignalRGen.Generator.Tests.TestData.CustomTypeDto> items);
+    public ReceiveGenericListDelegate? OnReceiveGenericList = default;
+    
     private global::System.Threading.Tasks.Task ReceiveGenericListHandler(List<global::SignalRGen.Generator.Tests.TestData.CustomTypeDto> items)
     {
         return OnReceiveGenericList?.Invoke(items) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -37,7 +39,9 @@ public class GenericTestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveDictionary of the <see cref = "global::SignalRGen.Clients.IGenericTestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<Dictionary<string, int>, global::System.Threading.Tasks.Task>? OnReceiveDictionary = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveDictionaryDelegate(Dictionary<string, int> keyValuePairs);
+    public ReceiveDictionaryDelegate? OnReceiveDictionary = default;
+    
     private global::System.Threading.Tasks.Task ReceiveDictionaryHandler(Dictionary<string, int> keyValuePairs)
     {
         return OnReceiveDictionary?.Invoke(keyValuePairs) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -45,7 +49,9 @@ public class GenericTestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveNestedGeneric of the <see cref = "global::SignalRGen.Clients.IGenericTestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<Dictionary<string, List<global::SignalRGen.Generator.Tests.TestData.CustomTypeDto>>, global::System.Threading.Tasks.Task>? OnReceiveNestedGeneric = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveNestedGenericDelegate(Dictionary<string, List<global::SignalRGen.Generator.Tests.TestData.CustomTypeDto>> complexData);
+    public ReceiveNestedGenericDelegate? OnReceiveNestedGeneric = default;
+    
     private global::System.Threading.Tasks.Task ReceiveNestedGenericHandler(Dictionary<string, List<global::SignalRGen.Generator.Tests.TestData.CustomTypeDto>> complexData)
     {
         return OnReceiveNestedGeneric?.Invoke(complexData) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -53,7 +59,9 @@ public class GenericTestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method SendAndReceiveGeneric of the <see cref = "global::SignalRGen.Clients.IGenericTestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<List<global::SignalRGen.Generator.Tests.TestData.CustomTypeDto>, global::System.Threading.Tasks.Task>? OnSendAndReceiveGeneric = default;
+    public delegate global::System.Threading.Tasks.Task SendAndReceiveGenericDelegate(List<global::SignalRGen.Generator.Tests.TestData.CustomTypeDto> input);
+    public SendAndReceiveGenericDelegate? OnSendAndReceiveGeneric = default;
+    
     private global::System.Threading.Tasks.Task SendAndReceiveGenericHandler(List<global::SignalRGen.Generator.Tests.TestData.CustomTypeDto> input)
     {
         return OnSendAndReceiveGeneric?.Invoke(input) ?? global::System.Threading.Tasks.Task.CompletedTask;

--- a/tests/SignalRGen.Generator.Tests/Snapshots/HubClientTests/HubClientTests.Generates_HubClient_WithLongMethodNames_Correctly#LongMethodNamesTestHubClient.g.verified.cs
+++ b/tests/SignalRGen.Generator.Tests/Snapshots/HubClientTests/HubClientTests.Generates_HubClient_WithLongMethodNames_Correctly#LongMethodNamesTestHubClient.g.verified.cs
@@ -29,7 +29,9 @@ public class LongMethodNamesTestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveVeryLongMethodNameThatExceedsNormalExpectationsForMethodNaming of the <see cref = "global::SignalRGen.Clients.ILongMethodNamesTestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<string, global::System.Threading.Tasks.Task>? OnReceiveVeryLongMethodNameThatExceedsNormalExpectationsForMethodNaming = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveVeryLongMethodNameThatExceedsNormalExpectationsForMethodNamingDelegate(string message);
+    public ReceiveVeryLongMethodNameThatExceedsNormalExpectationsForMethodNamingDelegate? OnReceiveVeryLongMethodNameThatExceedsNormalExpectationsForMethodNaming = default;
+    
     private global::System.Threading.Tasks.Task ReceiveVeryLongMethodNameThatExceedsNormalExpectationsForMethodNamingHandler(string message)
     {
         return OnReceiveVeryLongMethodNameThatExceedsNormalExpectationsForMethodNaming?.Invoke(message) ?? global::System.Threading.Tasks.Task.CompletedTask;

--- a/tests/SignalRGen.Generator.Tests/Snapshots/HubClientTests/HubClientTests.Generates_HubClient_WithNoPayload_Correctly#TestHubClient.g.verified.cs
+++ b/tests/SignalRGen.Generator.Tests/Snapshots/HubClientTests/HubClientTests.Generates_HubClient_WithNoPayload_Correctly#TestHubClient.g.verified.cs
@@ -29,7 +29,9 @@ public class TestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method NotifyNoAttributeApplied of the <see cref = "global::SignalRGen.Clients.ITestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<global::System.Threading.Tasks.Task>? OnNotifyNoAttributeApplied = default;
+    public delegate global::System.Threading.Tasks.Task NotifyNoAttributeAppliedDelegate();
+    public NotifyNoAttributeAppliedDelegate? OnNotifyNoAttributeApplied = default;
+    
     private global::System.Threading.Tasks.Task NotifyNoAttributeAppliedHandler()
     {
         return OnNotifyNoAttributeApplied?.Invoke() ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -37,7 +39,9 @@ public class TestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method NotifyServerToClient of the <see cref = "global::SignalRGen.Clients.ITestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<global::System.Threading.Tasks.Task>? OnNotifyServerToClient = default;
+    public delegate global::System.Threading.Tasks.Task NotifyServerToClientDelegate();
+    public NotifyServerToClientDelegate? OnNotifyServerToClient = default;
+    
     private global::System.Threading.Tasks.Task NotifyServerToClientHandler()
     {
         return OnNotifyServerToClient?.Invoke() ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -45,7 +49,9 @@ public class TestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method NotifyWithReturnNoAttributeApplied of the <see cref = "global::SignalRGen.Clients.ITestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<global::System.Threading.Tasks.Task>? OnNotifyWithReturnNoAttributeApplied = default;
+    public delegate global::System.Threading.Tasks.Task NotifyWithReturnNoAttributeAppliedDelegate();
+    public NotifyWithReturnNoAttributeAppliedDelegate? OnNotifyWithReturnNoAttributeApplied = default;
+    
     private global::System.Threading.Tasks.Task NotifyWithReturnNoAttributeAppliedHandler()
     {
         return OnNotifyWithReturnNoAttributeApplied?.Invoke() ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -53,7 +59,9 @@ public class TestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method NotifyWithReturnServerToClient of the <see cref = "global::SignalRGen.Clients.ITestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<global::System.Threading.Tasks.Task>? OnNotifyWithReturnServerToClient = default;
+    public delegate global::System.Threading.Tasks.Task NotifyWithReturnServerToClientDelegate();
+    public NotifyWithReturnServerToClientDelegate? OnNotifyWithReturnServerToClient = default;
+    
     private global::System.Threading.Tasks.Task NotifyWithReturnServerToClientHandler()
     {
         return OnNotifyWithReturnServerToClient?.Invoke() ?? global::System.Threading.Tasks.Task.CompletedTask;

--- a/tests/SignalRGen.Generator.Tests/Snapshots/HubClientTests/HubClientTests.Generates_HubClient_WithNullableTypes_Correctly#NullableTestHubClient.g.verified.cs
+++ b/tests/SignalRGen.Generator.Tests/Snapshots/HubClientTests/HubClientTests.Generates_HubClient_WithNullableTypes_Correctly#NullableTestHubClient.g.verified.cs
@@ -29,7 +29,9 @@ public class NullableTestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveNullableString of the <see cref = "global::SignalRGen.Clients.INullableTestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<string, global::System.Threading.Tasks.Task>? OnReceiveNullableString = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveNullableStringDelegate(string nullableMessage);
+    public ReceiveNullableStringDelegate? OnReceiveNullableString = default;
+    
     private global::System.Threading.Tasks.Task ReceiveNullableStringHandler(string nullableMessage)
     {
         return OnReceiveNullableString?.Invoke(nullableMessage) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -37,7 +39,9 @@ public class NullableTestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveNullableInt of the <see cref = "global::SignalRGen.Clients.INullableTestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<int?, global::System.Threading.Tasks.Task>? OnReceiveNullableInt = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveNullableIntDelegate(int? nullableNumber);
+    public ReceiveNullableIntDelegate? OnReceiveNullableInt = default;
+    
     private global::System.Threading.Tasks.Task ReceiveNullableIntHandler(int? nullableNumber)
     {
         return OnReceiveNullableInt?.Invoke(nullableNumber) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -45,7 +49,9 @@ public class NullableTestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveNullableCustomType of the <see cref = "global::SignalRGen.Clients.INullableTestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<global::SignalRGen.Generator.Tests.TestData.CustomTypeDto, global::System.Threading.Tasks.Task>? OnReceiveNullableCustomType = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveNullableCustomTypeDelegate(global::SignalRGen.Generator.Tests.TestData.CustomTypeDto nullableDto);
+    public ReceiveNullableCustomTypeDelegate? OnReceiveNullableCustomType = default;
+    
     private global::System.Threading.Tasks.Task ReceiveNullableCustomTypeHandler(global::SignalRGen.Generator.Tests.TestData.CustomTypeDto nullableDto)
     {
         return OnReceiveNullableCustomType?.Invoke(nullableDto) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -53,7 +59,9 @@ public class NullableTestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method NotifyWithNullableArray of the <see cref = "global::SignalRGen.Clients.INullableTestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<string[], global::System.Threading.Tasks.Task>? OnNotifyWithNullableArray = default;
+    public delegate global::System.Threading.Tasks.Task NotifyWithNullableArrayDelegate(string[] nullableArray);
+    public NotifyWithNullableArrayDelegate? OnNotifyWithNullableArray = default;
+    
     private global::System.Threading.Tasks.Task NotifyWithNullableArrayHandler(string[] nullableArray)
     {
         return OnNotifyWithNullableArray?.Invoke(nullableArray) ?? global::System.Threading.Tasks.Task.CompletedTask;

--- a/tests/SignalRGen.Generator.Tests/Snapshots/HubClientTests/HubClientTests.Generates_HubClient_WithValueTupleParameters_Correctly#ValueTupleTestHubClient.g.verified.cs
+++ b/tests/SignalRGen.Generator.Tests/Snapshots/HubClientTests/HubClientTests.Generates_HubClient_WithValueTupleParameters_Correctly#ValueTupleTestHubClient.g.verified.cs
@@ -29,7 +29,9 @@ public class ValueTupleTestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveTuple of the <see cref = "global::SignalRGen.Clients.IValueTupleTestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<(string name, int age), global::System.Threading.Tasks.Task>? OnReceiveTuple = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveTupleDelegate((string name, int age) person);
+    public ReceiveTupleDelegate? OnReceiveTuple = default;
+    
     private global::System.Threading.Tasks.Task ReceiveTupleHandler((string name, int age) person)
     {
         return OnReceiveTuple?.Invoke(person) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -37,7 +39,9 @@ public class ValueTupleTestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveNestedTuple of the <see cref = "global::SignalRGen.Clients.IValueTupleTestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<(string, (int, bool)), global::System.Threading.Tasks.Task>? OnReceiveNestedTuple = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveNestedTupleDelegate((string, (int, bool)) complexTuple);
+    public ReceiveNestedTupleDelegate? OnReceiveNestedTuple = default;
+    
     private global::System.Threading.Tasks.Task ReceiveNestedTupleHandler((string, (int, bool)) complexTuple)
     {
         return OnReceiveNestedTuple?.Invoke(complexTuple) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -45,7 +49,9 @@ public class ValueTupleTestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveNamedTuple of the <see cref = "global::SignalRGen.Clients.IValueTupleTestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<(string FirstName, string LastName, int Age), global::System.Threading.Tasks.Task>? OnReceiveNamedTuple = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveNamedTupleDelegate((string FirstName, string LastName, int Age) person);
+    public ReceiveNamedTupleDelegate? OnReceiveNamedTuple = default;
+    
     private global::System.Threading.Tasks.Task ReceiveNamedTupleHandler((string FirstName, string LastName, int Age) person)
     {
         return OnReceiveNamedTuple?.Invoke(person) ?? global::System.Threading.Tasks.Task.CompletedTask;

--- a/tests/SignalRGen.Generator.Tests/Snapshots/HubClientTests/HubClientTests.Generates_NamespaceNested_HubClient_Correctly#TestHubClient.g.verified.cs
+++ b/tests/SignalRGen.Generator.Tests/Snapshots/HubClientTests/HubClientTests.Generates_NamespaceNested_HubClient_Correctly#TestHubClient.g.verified.cs
@@ -29,7 +29,9 @@ public class TestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveCustomTypeUpdate of the <see cref = "global::SignalRGen.Clients.Nested.ITestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<IEnumerable<global::SignalRGen.Generator.Tests.TestData.CustomTypeDto>, global::System.Threading.Tasks.Task>? OnReceiveCustomTypeUpdate = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveCustomTypeUpdateDelegate(IEnumerable<global::SignalRGen.Generator.Tests.TestData.CustomTypeDto> customTypes);
+    public ReceiveCustomTypeUpdateDelegate? OnReceiveCustomTypeUpdate = default;
+    
     private global::System.Threading.Tasks.Task ReceiveCustomTypeUpdateHandler(IEnumerable<global::SignalRGen.Generator.Tests.TestData.CustomTypeDto> customTypes)
     {
         return OnReceiveCustomTypeUpdate?.Invoke(customTypes) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -37,7 +39,9 @@ public class TestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveFooUpdate of the <see cref = "global::SignalRGen.Clients.Nested.ITestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<string, int, global::System.Threading.Tasks.Task>? OnReceiveFooUpdate = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveFooUpdateDelegate(string bar, int bass);
+    public ReceiveFooUpdateDelegate? OnReceiveFooUpdate = default;
+    
     private global::System.Threading.Tasks.Task ReceiveFooUpdateHandler(string bar, int bass)
     {
         return OnReceiveFooUpdate?.Invoke(bar, bass) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -45,7 +49,9 @@ public class TestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveNormalTypeWithSpecificAttributeApplied of the <see cref = "global::SignalRGen.Clients.Nested.ITestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<string, int, global::System.Threading.Tasks.Task>? OnReceiveNormalTypeWithSpecificAttributeApplied = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveNormalTypeWithSpecificAttributeAppliedDelegate(string bazz, int buzz);
+    public ReceiveNormalTypeWithSpecificAttributeAppliedDelegate? OnReceiveNormalTypeWithSpecificAttributeApplied = default;
+    
     private global::System.Threading.Tasks.Task ReceiveNormalTypeWithSpecificAttributeAppliedHandler(string bazz, int buzz)
     {
         return OnReceiveNormalTypeWithSpecificAttributeApplied?.Invoke(bazz, buzz) ?? global::System.Threading.Tasks.Task.CompletedTask;
@@ -53,7 +59,9 @@ public class TestHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method ReceiveWithArbitraryAttribute of the <see cref = "global::SignalRGen.Clients.Nested.ITestHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<int, global::System.Threading.Tasks.Task>? OnReceiveWithArbitraryAttribute = default;
+    public delegate global::System.Threading.Tasks.Task ReceiveWithArbitraryAttributeDelegate(int blub);
+    public ReceiveWithArbitraryAttributeDelegate? OnReceiveWithArbitraryAttribute = default;
+    
     private global::System.Threading.Tasks.Task ReceiveWithArbitraryAttributeHandler(int blub)
     {
         return OnReceiveWithArbitraryAttribute?.Invoke(blub) ?? global::System.Threading.Tasks.Task.CompletedTask;

--- a/tests/SignalRGen.Generator.Tests/Snapshots/MultiProjectSupportTests/MultiProjectSupportTests.Generates_WithCustom_SignalRModuleName_Correctly#PingHubClient.g.verified.cs
+++ b/tests/SignalRGen.Generator.Tests/Snapshots/MultiProjectSupportTests/MultiProjectSupportTests.Generates_WithCustom_SignalRModuleName_Correctly#PingHubClient.g.verified.cs
@@ -29,7 +29,9 @@ public class PingHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method Ping of the <see cref = "global::MyCompany.App.Clients.IPingHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<global::System.Threading.Tasks.Task>? OnPing = default;
+    public delegate global::System.Threading.Tasks.Task PingDelegate();
+    public PingDelegate? OnPing = default;
+    
     private global::System.Threading.Tasks.Task PingHandler()
     {
         return OnPing?.Invoke() ?? global::System.Threading.Tasks.Task.CompletedTask;

--- a/tests/SignalRGen.Generator.Tests/Snapshots/MultiProjectSupportTests/MultiProjectSupportTests.Generates_WithDefault_SignalRModuleName_WhenMissing#DefaultHubClient.g.verified.cs
+++ b/tests/SignalRGen.Generator.Tests/Snapshots/MultiProjectSupportTests/MultiProjectSupportTests.Generates_WithDefault_SignalRModuleName_WhenMissing#DefaultHubClient.g.verified.cs
@@ -29,7 +29,9 @@ public class DefaultHubClient : HubClientBase
     /// <summary>
     /// Is invoked whenever the client method Notify of the <see cref = "global::MyCompany.App.Clients.IDefaultHub"/> gets invoked.
     /// </summary>
-    public global::System.Func<global::System.Threading.Tasks.Task>? OnNotify = default;
+    public delegate global::System.Threading.Tasks.Task NotifyDelegate();
+    public NotifyDelegate? OnNotify = default;
+    
     private global::System.Threading.Tasks.Task NotifyHandler()
     {
         return OnNotify?.Invoke() ?? global::System.Threading.Tasks.Task.CompletedTask;


### PR DESCRIPTION
## Summary
Refactored the `Func` based delegates to custom defined `delegate` definitions in order to preserve the parameter names.

## Related issues
Closes #118 