### PR TITLE
Update CI workflow to allow packing multiple projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
   # Projects to pack and publish
   PACK_PROJECTS: >
     src/SignalRGen/SignalRGen.csproj
-    src/SignalRGen.Testing/SignalRGen.Testing.csproj
+    src/testing/SignalRGen.Testing/SignalRGen.Testing.csproj
   # GitHub Packages Feed settings
   GITHUB_FEED: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Adds support for packaging multiple projects, e.g. `SignalRGen` and `SignalRGen.Testing`.

## Related issues
Closes #115 