### PR TITLE
Remove `--include-symbols` flag from dotnet pack in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           for proj in $PACK_PROJECTS; do
             echo "Packing $proj with version $packageVersion"
             dotnet pack -v normal -c Release -o ./artifacts --no-restore \
-              --include-symbols --include-source \
+              --include-source \
               -p:PackageVersion=$packageVersion \
               $proj
           done
@@ -121,7 +121,7 @@ jobs:
 
           for proj in $PACK_PROJECTS; do
             echo "Packing $proj with version $VERSION"
-            dotnet pack -v normal -c Release --include-symbols --include-source \
+            dotnet pack -v normal -c Release --include-source \
               -p:PackageVersion=$VERSION \
               -p:PackageReleaseNotes="See full release notes at: https://github.com/${{ github.repository }}/releases/tag/v$VERSION" \
               -o nupkg \


### PR DESCRIPTION
## Summary
Another attempt to fix the CI/CD pipeline symbols chaos.

## Related issues
No issue, hotfix