### PR TITLE
Update build targets to include `GenerateNuspec` before packing

### DIFF
--- a/src/SignalRGen/SignalRGen.csproj
+++ b/src/SignalRGen/SignalRGen.csproj
@@ -64,7 +64,7 @@
     </ItemGroup>
 
     <!-- Make sure that the abstraction dll is already built -->
-    <Target Name="BuildAbstractionsBeforePack" BeforeTargets="Pack">
+    <Target Name="BuildAbstractionsBeforePack" BeforeTargets="GenerateNuspec;Pack">
         <MSBuild Projects="..\SignalRGen.Abstractions\SignalRGen.Abstractions.csproj"
                  Targets="Build"
                  Properties="Configuration=$(Configuration);TargetFramework=net8.0;ContinuousIntegrationBuild=$(ContinuousIntegrationBuild);PackageVersion=$(PackageVersion)" />
@@ -77,7 +77,7 @@
     </Target>
 
     <!-- Report error when abstraction dll is missing -->
-    <Target Name="VerifyAbstractionsExist" BeforeTargets="Pack" AfterTargets="BuildAbstractionsBeforePack">
+    <Target Name="VerifyAbstractionsExist" BeforeTargets="GenerateNuspec;Pack" AfterTargets="BuildAbstractionsBeforePack">
         <Error Condition="!Exists('..\SignalRGen.Abstractions\bin\$(Configuration)\net8.0\SignalRGen.Abstractions.dll')"
                Text="Missing net8.0 abstractions output. Expected: ..\SignalRGen.Abstractions\bin\$(Configuration)\net8.0\SignalRGen.Abstractions.dll" />
         <Error Condition="!Exists('..\SignalRGen.Abstractions\bin\$(Configuration)\net9.0\SignalRGen.Abstractions.dll')"

--- a/src/testing/SignalRGen.Testing/SignalRGen.Testing.csproj
+++ b/src/testing/SignalRGen.Testing/SignalRGen.Testing.csproj
@@ -60,7 +60,7 @@
     </ItemGroup>
 
     <!-- Make sure that the abstraction dll is already built -->
-    <Target Name="BuildTestingAbstractionsBeforePack" BeforeTargets="Pack">
+    <Target Name="BuildTestingAbstractionsBeforePack" BeforeTargets="GenerateNuspec;Pack">
         <MSBuild Projects="..\SignalRGen.Testing.Abstractions\SignalRGen.Testing.Abstractions.csproj"
                  Targets="Build"
                  Properties="Configuration=$(Configuration);TargetFramework=net8.0;ContinuousIntegrationBuild=$(ContinuousIntegrationBuild);PackageVersion=$(PackageVersion)" />
@@ -73,7 +73,7 @@
     </Target>
 
     <!-- Report error when abstraction dll is missing -->
-    <Target Name="VerifyAbstractionsExist" BeforeTargets="Pack" AfterTargets="BuildTestingAbstractionsBeforePack">
+    <Target Name="VerifyAbstractionsExist" BeforeTargets="GenerateNuspec;Pack" AfterTargets="BuildTestingAbstractionsBeforePack">
         <Error Condition="!Exists('..\SignalRGen.Testing.Abstractions\bin\$(Configuration)\net8.0\SignalRGen.Testing.Abstractions.dll')"
                Text="Missing net8.0 abstractions output. Expected: ..\SignalRGen.Testing.Abstractions\bin\$(Configuration)\net8.0\SignalRGen.Testing.Abstractions.dll" />
         <Error Condition="!Exists('..\SignalRGen.Testing.Abstractions\bin\$(Configuration)\net9.0\SignalRGen.Testing.Abstractions.dll')"


### PR DESCRIPTION
## Summary
Force the build before generating the `nuspec` to ensure that the implicitly referenced dlls are properly built.

## Related issues
No issue, hotfix